### PR TITLE
Added getActiveLeads and getShortenedProject endpoints

### DIFF
--- a/src/back_end/api/end_points.js
+++ b/src/back_end/api/end_points.js
@@ -1,4 +1,4 @@
-import { ref, query, get, orderByChild, startAt, endAt, limitToFirst, limitToLast} from "firebase/database";
+import { ref, query, get, orderByChild, startAt, endAt, limitToFirst, limitToLast, equalTo} from "firebase/database";
 import { database } from "../utils/index.js";
 import { getData } from "../utils/utils.js";
 
@@ -77,4 +77,47 @@ export async function getEventsBasedOnTime(upcoming, limit = 4, test = "Events")
 export async function getProjects(test = "Projects") {
   let data = await getData(test);
   return data;
+}
+
+/*
+ * Returns all Active Club_Leads
+ */
+export async function getActiveLeads(test = "Club_Leads") {
+  let qRes;
+  let data;
+  try {
+    let q = query(ref(database, test),orderByChild('Active'), equalTo(true));
+    qRes = await get(q);
+    data = qRes.val();
+  } catch (err) {
+    console.error(err);
+    return;
+  }
+  return Array.from(Object.values(data));
+}
+
+/*
+ * Returns all projects in shortened form.
+ */
+export async function getShortenedProject(test = "Projects") {
+  let qRes;
+  let data;
+  try {
+    let q = query(ref(database, test));
+    qRes = await get(q);
+    data = qRes.val();
+  } catch (err) {
+    console.error(err);
+    return;
+  }
+  let values = Array.from(Object.values(data))
+  let returnVals = [];
+  values.forEach((val) => {
+    returnVals.push(
+      {"Name": val['Name'],
+      "Description": val['Description'],
+      "Image": val['Image'] 
+      })
+  })
+  return returnVals;
 }

--- a/src/back_end/docs/Leads.md
+++ b/src/back_end/docs/Leads.md
@@ -1,5 +1,5 @@
 ## <span style="color:deepskyblue">Leads Data Endpoints</span>
-Documentation for all callable back-end functions related to Events data
+Documentation for all callable back-end functions related to Leads data
 
 ## <span style="color:deepskyblue"> getActiveLeads
 Returns all club leads (and information associated) that are currently active.

--- a/src/back_end/docs/Leads.md
+++ b/src/back_end/docs/Leads.md
@@ -1,0 +1,43 @@
+## <span style="color:deepskyblue">Leads Data Endpoints</span>
+Documentation for all callable back-end functions related to Events data
+
+## <span style="color:deepskyblue"> getActiveLeads
+Returns all club leads (and information associated) that are currently active.
+
+* **Function Call:** getActiveLeads()
+
+* **Returned Data Format:** List
+
+* **Success Response: ()** <br>
+Sample response shows output format, followed by sample data.
+  ```
+  [
+    {
+      Active: <Boolean>,
+      Class_Standing: <String>,
+      Date_Joined: <DateString>,
+      Date_Left: <DateString>,
+      Email: <String>,
+      Image: <URL>,
+      Name: <String>,
+      Role: <String>,
+      Team: <String>
+    },
+    {
+      Active: true,
+      Class_Standing: 'Senior',
+      Date_Joined: '6/30/2021',
+      Date_Left: 'NA',
+      Email: 'something@gmail.com',
+      Image: 'NA',
+      Name: 'Billy',
+      Role: 'Co-Chair',
+      Team: 'Project1'
+    },
+    ...
+  ]
+  ```
+
+* **Error Response:**
+  Errors will be outputted into console
+

--- a/src/back_end/docs/Projects.md
+++ b/src/back_end/docs/Projects.md
@@ -1,0 +1,31 @@
+## <span style="color:deepskyblue">Projects Data Endpoints</span>
+Documentation for all callable back-end functions related to Events data
+
+## <span style="color:deepskyblue"> getShortenedProject
+Returns all projects in shortened form (Name, Description, Image).
+
+* **Function Call:** getShortenedProject()
+
+* **Returned Data Format:** List
+
+* **Success Response: ()** <br>
+Sample response shows output format, followed by sample data.
+  ```
+  [
+    {
+      Name: <String>,
+      Description: <String>,
+      Image: <URL>
+    },
+    {
+      Name: 'Project1',
+      Description: 'testdesc',
+      Image: 'blob'
+    },
+    ...
+  ]
+  ```
+
+* **Error Response:**
+  Errors will be outputted into console
+

--- a/src/back_end/docs/Projects.md
+++ b/src/back_end/docs/Projects.md
@@ -1,5 +1,5 @@
 ## <span style="color:deepskyblue">Projects Data Endpoints</span>
-Documentation for all callable back-end functions related to Events data
+Documentation for all callable back-end functions related to Projects data
 
 ## <span style="color:deepskyblue"> getShortenedProject
 Returns all projects in shortened form (Name, Description, Image).

--- a/src/back_end/docs/README.md
+++ b/src/back_end/docs/README.md
@@ -7,7 +7,7 @@ Ben:
 - Endpoint Documentation                (This PR)
 
 Frank:
-- Return old events / upcoming events   (This PR)
+- Return old events / upcoming events   (Done)
 - Return details for projects           (TODO)
 - Return all currently active projects  (TODO)
 - Endpoint Documentation                (TODO)

--- a/src/back_end/docs/README.md
+++ b/src/back_end/docs/README.md
@@ -2,9 +2,9 @@ General README for these functions... we can fill it out at some point @Ben
 But for now I will use this as a TODO list.
 
 Ben:
-- Return active club leads              (TODO)
-- Return shortened form of projects     (TODO)
-- Endpoint Documentation                (TODO)
+- Return active club leads              (This PR)
+- Return shortened form of projects     (This PR)
+- Endpoint Documentation                (This PR)
 
 Frank:
 - Return old events / upcoming events   (This PR)

--- a/src/back_end/package.json
+++ b/src/back_end/package.json
@@ -9,8 +9,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "mocha test/*.js --exit",
-    "testEvents": "mocha test/testEvents.js --exit"
+    "test": "mocha test/*.js --exit"
   },
   "author": "Ben,Frank,Wu",
   "license": "ISC",

--- a/src/back_end/test/testActive.js
+++ b/src/back_end/test/testActive.js
@@ -1,0 +1,23 @@
+import { getActiveLeads } from "../api/end_points.js";
+import {assert} from 'chai';
+
+describe("Testing Get Active Leads Functions.", () => {
+    it('Active Leads',async () => {
+      let rsp = await getActiveLeads("Test/Club_Leads");
+      let expected =
+      [
+        {
+          Active: true,
+          Class_Standing: 'Senior',
+          Date_Joined: '6/30/2021',
+          Date_Left: 'NA',
+          Email: 'something@gmail.com',
+          Image: 'NA',
+          Name: 'Billy',
+          Role: 'Co-Chair',
+          Team: 'Project1'
+        }
+      ];
+      assert.deepEqual(rsp, expected);
+    })
+})

--- a/src/back_end/test/testEvents.js
+++ b/src/back_end/test/testEvents.js
@@ -1,7 +1,7 @@
 import { getEventsBasedOnTime } from '../api/end_points.js';
 import { assert } from 'chai';
 
-describe( "Testing event endpionts", () => {
+describe( "Testing event endpoints", () => {
   it('Get upcoming events', async() => {
     let get = await getEventsBasedOnTime(true, 4, "Test/Events");
     let expected = [

--- a/src/back_end/test/testGetAll.js
+++ b/src/back_end/test/testGetAll.js
@@ -13,9 +13,21 @@ describe("Testing Get all Functions.", () => {
         Date_Left: 'NA',
         Email: 'something@gmail.com',
         Image: 'NA',
+        Name: 'Billy',
         Role: 'Co-Chair',
         Team: 'Project1'
-      }
+      },
+      Joe: {
+        Active: false,
+        Class_Standing: "Junior",
+        Date_Joined: "5/2/2020",
+        Date_Left: "6/30/2021",
+        Email: "another@gmail.com",
+        Image: "N/A",
+        Name: "Joe",
+        Role: "Treasurer",
+        Team: "Project2",
+        }
     };
     assert.deepEqual(rsp, expected);
   })
@@ -30,7 +42,17 @@ describe("Testing Get all Functions.", () => {
         Description: 'This is a dope event',
         Image: 'blob',
         Location: 'UW',
+        Name: "Event1",
         Sponsor: 'Google'
+      },
+      Event2: {
+        Attendees: 24,
+        Date: "2008-10-20T16:00-07:00",
+        Description: "Social event",
+        Image: "blob",
+        Location: "UW",
+        Name: "Event2",
+        Sponsor: "Kasey",
       },
       EventFuture: {
         Attendees: 21,
@@ -38,6 +60,7 @@ describe("Testing Get all Functions.", () => {
         Description: 'This is an event in the future',
         Image: 'blob',
         Location: 'UW?',
+        Name: 'EventFuture',
         Sponsor: 'Tettie'
       }
     };
@@ -56,8 +79,21 @@ describe("Testing Get all Functions.", () => {
         Git_Link: 'link',
         Image: 'Image',
         Members: 'Billy',
+        Name: 'Project1',
         PM: 'Billy',
         Start_Date: '1/1/2001'
+      },
+      Project2: {
+        Category: "Web_project",
+        Completed: true,
+        Description: "TestDesc",
+        End_Date: "",
+        Git_link: "link",
+        Image: "Image",
+        Members: "Billy,Joe",
+        Name: "Project2",
+        PM: "Joe",
+        Start_Date: "1/1/2020",
       }
     };
     assert.deepEqual(rsp, expected);

--- a/src/back_end/test/testShortenedProjects.js
+++ b/src/back_end/test/testShortenedProjects.js
@@ -1,0 +1,14 @@
+import { getShortenedProject } from "../api/end_points.js";
+import {assert} from 'chai';
+
+describe("Testing Get Shortened Project Functions.", () => {
+    it('Shortened Project',async () => {
+      let rsp = await getShortenedProject("Test/Projects");
+      let expected =
+      [
+        { Name: 'Project1', Description: 'testdesc', Image: 'Image' },
+        { Name: 'Project2', Description: 'TestDesc', Image: 'Image' }
+      ]
+      assert.deepEqual(rsp, expected);
+    })
+})


### PR DESCRIPTION
Implemented endpoint to return all active club leads and information associated. Also implemented the endpoint to return all projects in shortened form (Name, Description, Image). Both endpoints return in the same list format similar to  @ASimpleFox 's endpoint to keep with consistency of return data (Look at .MD files for more info).

**IMPORTANT**
I changed the database structure to add a `Name` Parameter for Club_Leads and Projects to make the querying a lot easier.

Changelog:
- Added `getActiveLeads` in `end_points.js`
- Added getShortenedProject in `end_points.js`
- Added testing files for active leads and shortened projects: `testActive.js` `testShortenedProject.js`
- Fixed getAll tests to be in-line with the new test data implemented
- Added documentation in docs folder (`src/api/docs`) for each endpoint. The README.md has been updated to show what was done in this PR

Notes:
- I am aware two endpoints at once is a big no-no in real-life production but I didn't realize until after I made both so I'll keep it in mind for next time!