### PR TITLE
Hotfixing output for getall endpoints

### DIFF
--- a/src/back_end/api/end_points.js
+++ b/src/back_end/api/end_points.js
@@ -6,14 +6,14 @@ import { getData } from "../utils/utils.js";
 // Returns all club leads from database
 export async function getLeads(test = "Club_Leads") {
   let data = await getData(test);
-  return data;
+  return Array.from(Object.values(data));
 }
 
 /* -------------------- Events Endpoints -------------------- */
 // Returns all events from database
 export async function getAllEvents(test = "Events") {
   let data = await getData(test);
-  return data;
+  return Array.from(Object.values(data));
 }
 
 /*
@@ -76,7 +76,7 @@ export async function getEventsBasedOnTime(upcoming, limit = 4, test = "Events")
 // Returns all projects from database
 export async function getProjects(test = "Projects") {
   let data = await getData(test);
-  return data;
+  return Array.from(Object.values(data));
 }
 
 /*

--- a/src/back_end/test/testGetAll.js
+++ b/src/back_end/test/testGetAll.js
@@ -5,8 +5,8 @@ describe("Testing Get all Functions.", () => {
   it('Get All Officers',async () => {
     let rsp = await getLeads("Test/Club_Leads");
     let expected =
-    {
-      Billy: {
+    [
+      {
         Active: true,
         Class_Standing: 'Senior',
         Date_Joined: '6/30/2021',
@@ -17,7 +17,7 @@ describe("Testing Get all Functions.", () => {
         Role: 'Co-Chair',
         Team: 'Project1'
       },
-      Joe: {
+      {
         Active: false,
         Class_Standing: "Junior",
         Date_Joined: "5/2/2020",
@@ -28,15 +28,15 @@ describe("Testing Get all Functions.", () => {
         Role: "Treasurer",
         Team: "Project2",
         }
-    };
+    ];
     assert.deepEqual(rsp, expected);
   })
 
   it('Get All Events', async () => {
     let rsp = await getAllEvents("Test/Events");
     let expected =
-    {
-      Event1: {
+    [
+      {
         Attendees: 69,
         Date: '2007-10-20T16:00-07:00',
         Description: 'This is a dope event',
@@ -45,7 +45,7 @@ describe("Testing Get all Functions.", () => {
         Name: "Event1",
         Sponsor: 'Google'
       },
-      Event2: {
+      {
         Attendees: 24,
         Date: "2008-10-20T16:00-07:00",
         Description: "Social event",
@@ -54,7 +54,7 @@ describe("Testing Get all Functions.", () => {
         Name: "Event2",
         Sponsor: "Kasey",
       },
-      EventFuture: {
+      {
         Attendees: 21,
         Date: '2192-10-20T16:00-07:00',
         Description: 'This is an event in the future',
@@ -63,15 +63,15 @@ describe("Testing Get all Functions.", () => {
         Name: 'EventFuture',
         Sponsor: 'Tettie'
       }
-    };
+    ];
     assert.deepEqual(rsp, expected);
   })
 
   it('Get All Projects', async () => {
     let rsp = await getProjects("Test/Projects");
     let expected =
-    {
-      Project1: {
+    [
+      {
         Category: 'Web_Project',
         Completed: false,
         Description: 'testdesc',
@@ -83,7 +83,7 @@ describe("Testing Get all Functions.", () => {
         PM: 'Billy',
         Start_Date: '1/1/2001'
       },
-      Project2: {
+      {
         Category: "Web_project",
         Completed: true,
         Description: "TestDesc",
@@ -95,7 +95,7 @@ describe("Testing Get all Functions.", () => {
         PM: "Joe",
         Start_Date: "1/1/2020",
       }
-    };
+    ];
     assert.deepEqual(rsp, expected);
   })
 })


### PR DESCRIPTION
Hotfixing the output

Changelog:
- Updating get all functions to return list of objects instead of objects.objects
- Fixed tests relating to those endpoints